### PR TITLE
Feature/safe stream close

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -26,6 +26,7 @@ func NewStream() *Stream {
 
 // ServeHTTP sets up a stream (SSE) connection to the client
 // Panics if called more than once
+// Panics if http.ReposneWriter doesn't implement http.Flusher and http.CloseNotifier
 // Stream is to be considered closed on return
 func (s *Stream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Ensure only one call
@@ -84,7 +85,7 @@ func (s *Stream) Retry(milliseconds int) {
 }
 
 // Close the connection to the client
-// All functions becomes no-op
+// All functions becomes no-ops
 func (s *Stream) Close() {
 	select {
 	case <-s.closeNotifier:

--- a/stream_test.go
+++ b/stream_test.go
@@ -129,3 +129,17 @@ func TestStream_MultiClose(t *testing.T) {
 	require.NotPanics(t, unit.Close)
 	require.NotPanics(t, unit.Close)
 }
+
+func TestStream_MultiServeHTTP(t *testing.T) {
+	recorder := ResponseRecorderWrapper{
+		ResponseRecorder: httptest.NewRecorder(),
+		closer:           make(chan bool),
+	}
+	unit := NewStream()
+
+	go require.NotPanics(t, func() { unit.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil)) })
+	time.Sleep(time.Second) // Give go routine time to start
+	require.Panics(t, func() { unit.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil)) },
+		"Second call to ServeHTTP should panic!")
+	require.NotPanics(t, unit.Close)
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -108,3 +108,24 @@ func TestStream_Close(t *testing.T) {
 	case <-responseNotifier:
 	}
 }
+
+func TestStream_SendCloseDeadlock(t *testing.T) {
+	recorder := ResponseRecorderWrapper{
+		ResponseRecorder: httptest.NewRecorder(),
+		closer:           make(chan bool),
+	}
+	unit := NewStream()
+	go unit.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	unit.Ping()
+	unit.Close()
+	unit.Ping()
+	unit.Ping()
+	unit.Ping()
+}
+
+func TestStream_MultiClose(t *testing.T) {
+	unit := NewStream()
+	require.NotPanics(t, unit.Close)
+	require.NotPanics(t, unit.Close)
+}


### PR DESCRIPTION
* Fixes deadlock when sending on a closed stream
* Fixes panic when closing a stream multiple times
* Added panic if ServeHTTP is called more than once to prevent incorrect usage